### PR TITLE
[FIX] module account_contract_proyect fail to install

### DIFF
--- a/account_contract_project/__openerp__.py
+++ b/account_contract_project/__openerp__.py
@@ -25,8 +25,8 @@
     'website': 'www.adhoc.com.ar',
     "category": "Accounting",
     "description": """
- Account Contract Project
- ========================
+Account Contract Project
+========================
     """,
     'depends': [
         'project'


### PR DESCRIPTION
When installing module it fails with this message:

...stripping first lines...

  File "/usr/lib/python2.7/dist-packages/docutils/parsers/rst/states.py", line 283, in nested_parse
    node=node, match_titles=match_titles)
  File "/usr/lib/python2.7/dist-packages/docutils/parsers/rst/states.py", line 196, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "/usr/lib/python2.7/dist-packages/docutils/statemachine.py", line 239, in run
    context, state, transitions)
  File "/usr/lib/python2.7/dist-packages/docutils/statemachine.py", line 460, in check_line
    return method(match, context, next_state)
  File "/usr/lib/python2.7/dist-packages/docutils/parsers/rst/states.py", line 2721, in underline
    source=src, line=srcline)
  File "/usr/lib/python2.7/dist-packages/docutils/utils/**init**.py", line 235, in severe
    return self.system_message(self.SEVERE_LEVEL, _args, *_kwargs)
  File "/usr/lib/python2.7/dist-packages/docutils/utils/**init**.py", line 193, in system_message
    raise SystemMessage(msg, level)
SystemMessage: <string>:3: (SEVERE/4) Unexpected section title.

  Account Contract Project
 ========================
