### PR TITLE
[FIX][8.0][stock_voucher] Default value 'book_id' when 'book_required' is true

### DIFF
--- a/stock_voucher/wizard/stock_print_remit.py
+++ b/stock_voucher/wizard/stock_print_remit.py
@@ -14,8 +14,6 @@ class stock_print_stock_voucher(models.TransientModel):
     @api.model
     def _get_picking(self):
         active_id = self._context.get('active_id', False)
-        if not active_id:
-            active_id = 24
         return self.env['stock.picking'].browse(active_id)
 
     @api.model

--- a/stock_voucher/wizard/stock_transfer_details.py
+++ b/stock_voucher/wizard/stock_transfer_details.py
@@ -55,10 +55,6 @@ class stock_transfer_details(models.TransientModel):
                 ))
         return estimated_number_of_pages
 
-    @api.onchange('picking_id')
-    def onchange_picking(self):
-        self.book_id = self.picking_id.picking_type_id.book_id
-
     @api.multi
     def do_detailed_transfer(self):
         self.ensure_one()

--- a/stock_voucher/wizard/stock_transfer_details.py
+++ b/stock_voucher/wizard/stock_transfer_details.py
@@ -13,8 +13,6 @@ class stock_transfer_details(models.TransientModel):
     @api.model
     def _get_picking(self):
         active_id = self._context.get('active_id', False)
-        if not active_id:
-            active_id = 24
         return self.env['stock.picking'].browse(active_id)
 
     @api.model

--- a/stock_voucher/wizard/stock_transfer_details.py
+++ b/stock_voucher/wizard/stock_transfer_details.py
@@ -10,12 +10,25 @@ from math import ceil
 class stock_transfer_details(models.TransientModel):
     _inherit = 'stock.transfer_details'
 
+    @api.model
+    def _get_picking(self):
+        active_id = self._context.get('active_id', False)
+        if not active_id:
+            active_id = 24
+        return self.env['stock.picking'].browse(active_id)
+
+    @api.model
+    def _get_book(self):
+        picking = self._get_picking()
+        return picking.picking_type_id.book_id
+
     book_required = fields.Boolean(
         related='picking_id.picking_type_id.book_required'
         )
     book_id = fields.Many2one(
         'stock.book',
         'Book',
+        default=_get_book,
         )
     # block_estimated_number_of_pages = fields.Boolean(
     #     related='book_id.block_estimated_number_of_pages',


### PR DESCRIPTION
Copie la funcionalidad de `stock_print_remit` a `stock_transfer_details`, para que complete automáticamente el `book_id` de acuerdo a lo configurado en `stock.picking.type`. 

Revisando el código se sugiere que esa era la intención original (`@api.onchange('picking_id')`), pero por alguna razón nunca funcionó. Haciendo algunas pruebas, parece que `picking_id` nunca está definido, lo cual es raro, pero por eso no funcionaba. Me tomé el atrevimiento de eliminar ese bloque, ya que parece no tener finalidad.

Pero la verdad no tengo experiencia con  `odoo` así que puedo estar terriblemente equivocado. Por esa razón, además, me limité únicamente a copiar y pegar parte del código de un archivo a otro, sin modificar nada que no sea necesario.

Pero, sin entender demasiado, estas líneas me hacen mucho ruido:

```
        if not active_id:
            active_id = 24
```

¿¿Está bien eso ahí??

Por las dudas lo dejé tal cual lo encontré, pero si es en efecto algo que no debería estar ahí, hay que corregirlo también en `stock_print_remit`.
